### PR TITLE
Add TON blockchain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AddrMint is a high-performance tool for generating large quantities of blockchain addresses (Ethereum, Bitcoin, and Solana). It features advanced concurrency optimizations for maximum throughput when generating millions or billions of addresses.
+AddrMint is a high-performance tool for generating large quantities of blockchain addresses (Ethereum, Bitcoin, Solana, and TON). It features advanced concurrency optimizations for maximum throughput when generating millions or billions of addresses.
 
 In CipherOwl we use this tool to generate addresses to test various of data workloads.
 
@@ -49,12 +49,12 @@ go build -o addrmint main.go
 ## Usage
 
 ```
-./addrmint --network [ethereum|bitcoin|solana] --count [number] --seed [optional_integer_seed] --workers [optional_worker_count] --batch-size [optional_batch_size] --output-buffer [optional_buffer_size] --output [optional_output_file] --generate-hash
+./addrmint --network [ethereum|bitcoin|solana|ton] --count [number] --seed [optional_integer_seed] --workers [optional_worker_count] --batch-size [optional_batch_size] --output-buffer [optional_buffer_size] --output [optional_output_file] --generate-hash
 ```
 
 ### Parameters
 
-- `--network`: The blockchain network (ethereum, bitcoin, or solana) (required)
+- `--network`: The blockchain network (ethereum, bitcoin, solana, or ton) (required)
 - `--count`: Number of addresses to generate (default: 1)
 - `--seed`: Random seed as an integer (default: 0, which generates a random seed)
 - `--workers`: Number of concurrent workers (default: number of CPU cores)
@@ -78,6 +78,11 @@ Generate 1000 Bitcoin addresses with a specific seed and save to a file:
 Generate 5 Solana addresses:
 ```
 ./addrmint --network solana --count 5
+```
+
+Generate 10 TON addresses:
+```
+./addrmint --network ton --count 10
 ```
 
 Generate 1 million Ethereum addresses using 16 workers and a large output buffer:

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,11 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/ethereum/go-ethereum v1.16.8
+	github.com/xssnick/tonutils-go v1.15.5
 )
 
 require (
-	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
-filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -87,6 +87,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/xssnick/tonutils-go v1.15.5 h1:yAcHnDaY5QW0aIQE47lT0PuDhhHYE+N+NyZssdPKR0s=
+github.com/xssnick/tonutils-go v1.15.5/go.mod h1:3/B8mS5IWLTd1xbGbFbzRem55oz/Q86HG884bVsTqZ8=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/main_test.go
+++ b/main_test.go
@@ -58,6 +58,36 @@ func TestGenerateSolanaAddress(t *testing.T) {
 	}
 }
 
+// TestGenerateTonAddress tests the TON address generation
+func TestGenerateTonAddress(t *testing.T) {
+	// Use a fixed seed for reproducible testing
+	seed := "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3"
+
+	address := generateTonAddress(seed)
+
+	// TON user-friendly addresses are 48 characters (base64 encoded)
+	if len(address) != 48 {
+		t.Errorf("Expected TON address length to be 48, got %d (address: %s)", len(address), address)
+	}
+
+	// Non-bounceable mainnet addresses start with "UQ"
+	if !strings.HasPrefix(address, "UQ") {
+		t.Errorf("Expected TON address to start with 'UQ', got %s", address)
+	}
+}
+
+// TestGenerateTonAddressDeterministic tests that TON address generation is deterministic
+func TestGenerateTonAddressDeterministic(t *testing.T) {
+	seed := "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3"
+
+	addr1 := generateTonAddress(seed)
+	addr2 := generateTonAddress(seed)
+
+	if addr1 != addr2 {
+		t.Errorf("TON address generation not deterministic: %s != %s", addr1, addr2)
+	}
+}
+
 // TestProgressBar tests the progress bar functionality
 func TestProgressBar(t *testing.T) {
 	// Redirect stderr to capture output
@@ -238,8 +268,8 @@ func TestBatchSubmitJobs(t *testing.T) {
 // TestWorker tests the worker function
 func TestWorker(t *testing.T) {
 	// Create channels
-	jobs := make(chan Job, 3)
-	results := make(chan Result, 3)
+	jobs := make(chan Job, 4)
+	results := make(chan Result, 4)
 	var wg sync.WaitGroup
 
 	// Start worker
@@ -250,6 +280,7 @@ func TestWorker(t *testing.T) {
 	jobs <- Job{index: 0, seed: "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3", network: "ethereum"}
 	jobs <- Job{index: 1, seed: "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3", network: "bitcoin"}
 	jobs <- Job{index: 2, seed: "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3", network: "solana"}
+	jobs <- Job{index: 3, seed: "c8c5e5a7f326a2b5f3eee778db6856430d808c32b16e18d8228a93e3d94791a3", network: "ton"}
 	close(jobs)
 
 	// Wait for worker to finish
@@ -263,7 +294,7 @@ func TestWorker(t *testing.T) {
 	// Verify results
 	resultCount := 0
 	for result := range results {
-		if result.index < 0 || result.index > 2 {
+		if result.index < 0 || result.index > 3 {
 			t.Errorf("Unexpected result index: %d", result.index)
 		}
 		if result.address == "" {
@@ -276,7 +307,7 @@ func TestWorker(t *testing.T) {
 	<-done
 
 	// Check that we got all results
-	if resultCount != 3 {
-		t.Errorf("Expected 3 results, got %d", resultCount)
+	if resultCount != 4 {
+		t.Errorf("Expected 4 results, got %d", resultCount)
 	}
 }


### PR DESCRIPTION
## Summary

- Add TON (The Open Network) blockchain address generation support
- Implement `generateTonAddress()` using V5R1 wallet (modern standard)
- Generate non-bounceable mainnet addresses (UQ... format)
- Add comprehensive tests for TON address generation

## Changes

- Added `tonutils-go` dependency for TON cryptography
- Added TON case to network validation and worker switch
- Added `TestGenerateTonAddress` and `TestGenerateTonAddressDeterministic` tests
- Updated README with TON examples

## Usage

```bash
# Generate 10 TON addresses
./addrmint --network ton --count 10

# Generate with specific seed (deterministic)
./addrmint --network ton --count 5 --seed 42
```

## Test Plan

- [x] All existing tests pass
- [x] New TON tests pass
- [x] CLI works with `--network ton`
- [x] Addresses are deterministic with same seed
- [x] Addresses have correct format (48 chars, starts with "UQ")